### PR TITLE
fix: Documented shortcut for GitHub code search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Helpful GitHub Assistant for Alfred.
 	+ <kbd>⌃⏎</kbd>: Clone the repo to a local folder and open in the Terminal.
 	  Optionally, creates a fork on GitHub with the `gh` cli and prepares the
 	  repo for a PR.
-	+ <kbd>⌥⏎</kbd>: Search the repo for a query via GitHub Code Search.
+	+ <kbd>⇧⏎</kbd>: Search the repo for a query via GitHub Code Search.
 - Access public repositories you own via `gmy`.
 	+ <kbd>⏎</kbd>: If the repo is available locally on your device, open it in
 	  Finder. Otherwise, open the repo's GitHub page.

--- a/info.plist
+++ b/info.plist
@@ -1469,7 +1469,7 @@
 	+ &lt;kbd&gt;⌃⏎&lt;/kbd&gt;: Clone the repo to a local folder and open in the Terminal.
 	  Optionally, creates a fork on GitHub with the `gh` cli and prepares the
 	  repo for a PR.
-	+ &lt;kbd&gt;⌥⏎&lt;/kbd&gt;: Search the repo for a query via GitHub Code Search.
+	+ &lt;kbd&gt;⇧⏎&lt;/kbd&gt;: Search the repo for a query via GitHub Code Search.
 - Access public repositories you own via `gmy`.
 	+ &lt;kbd&gt;⏎&lt;/kbd&gt;: If the repo is available locally on your device, open it in
 	  Finder. Otherwise, open the repo's GitHub page.


### PR DESCRIPTION
## Checklist
- [ ] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.