### PR TITLE
improv: Support for showing private PRs with the gpr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Helpful GitHub assistant for Alfred.
 	+ <kbd>⏎</kbd>: Open the issue in the browser.
 	+ <kbd>⌥⏎</kbd>: Copy the issue URL.
 - Access Pull Requests (PRs) you have opened with the keyword `gpr`.
+    + Optional [GitHub Token](https://github.com/settings/tokens) with access
+	  to private PRs.
 	+ <kbd>⏎</kbd>: Open the PR in the browser.
 	+ <kbd>⌥⏎</kbd>: Copy the link to the PR.
 - Directly open your GitHub notification via `ghn`.

--- a/info.plist
+++ b/info.plist
@@ -1426,8 +1426,8 @@
 	</array>
 	<key>readme</key>
 	<string>## ℹ️ Recent change
-`restore mtime` has been reworked to be magnitudes quicker. 
-If you have enabled it in past versions, please check your workflow configuration, 
+`restore mtime` has been reworked to be magnitudes quicker.
+If you have enabled it in past versions, please check your workflow configuration,
 since there are now different options for it.
 
 ## Usage
@@ -1739,7 +1739,7 @@ since there are now different options for it.
 			<key>colorindex</key>
 			<integer>8</integer>
 			<key>note</key>
-			<string>DOUBLE-CLICK THIS 
+			<string>DOUBLE-CLICK THIS
 
 to set a hotkey to clone the repo in the frontmost browser tab</string>
 			<key>xpos</key>
@@ -2038,7 +2038,7 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string>GitHub Token. If empty, will fallback to `$GITHUB_TOKEN` exported in `.zshenv`. (Only needed for showing notifications via `ghn`.)</string>
+			<string>GitHub Token. If empty, will fallback to `$GITHUB_TOKEN` exported in `.zshenv`. (Needed for showing notifications via `ghn`. Optional for `gpr` to show PRs in private repositories.)</string>
 			<key>label</key>
 			<string>Notifications</string>
 			<key>type</key>
@@ -2053,3 +2053,4 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 	<string>https://chris-grieser.de/</string>
 </dict>
 </plist>
+

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -11,11 +11,20 @@ function alfredMatcher(str) {
 	return [clean, camelCaseSeparated, str].join(" ") + " ";
 }
 
-/** @param {string} url @return {string} */
-function httpRequest(url) {
-	const queryURL = $.NSURL.URLWithString(url);
-	const data = $.NSData.dataWithContentsOfURL(queryURL);
-	return $.NSString.alloc.initWithDataEncoding(data, $.NSUTF8StringEncoding).js;
+/**
+ * @param {string} url
+ * @param {string[]} header
+ * @param {string=} extraOpts
+ * @return {string} response
+ */
+function httpRequestWithHeaders(url, header, extraOpts) {
+	let allHeaders = "";
+	for (const line of header) {
+		allHeaders += `-H "${line}" `;
+	}
+	extraOpts = extraOpts || "";
+	const curlRequest = `curl -L ${allHeaders} "${url}" ${extraOpts}`;
+	return app.doShellScript(curlRequest);
 }
 
 /**
@@ -56,8 +65,19 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: alfred_run
 function run() {
 	const username = $.getenv("github_username");
+	const githubToken = $.getenv("github_token_from_alfred_prefs").trim() || app.
+		doShellScript("test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN")
+		.trim();
+
 	const apiURL = `https://api.github.com/search/issues?q=author:${username}+is:pr+is:open&per_page=100`;
-	const response = httpRequest(apiURL);
+	let headers = [
+		"Accept: application/vnd.github.v3+json",
+		"X-GitHub-Api-Version: 2022-11-28",
+	];
+	if (githubToken) {
+		headers.push(`Authorization: BEARER ${githubToken}`);
+	}
+	const response = httpRequestWithHeaders(apiURL, headers);
 	if (!response) {
 		return JSON.stringify({
 			items: [{ title: "No response from GitHub.", subtitle: "Try again later.", valid: false }],


### PR DESCRIPTION
## What problem does this PR solve?
Lack of support for showing private PRs with the `gpr` command.

## How does the PR solve it?
By reusing the `httpRequestWithHeaders` function from the notification code and conditionally including the `githubToken` in the request, this PR enables the fetching of PRs in private repositories.

Fixes: #9 

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
